### PR TITLE
attempting to avoid captcha/ratelimiting

### DIFF
--- a/fundgrube.clj
+++ b/fundgrube.clj
@@ -52,6 +52,7 @@
            offset offset
            run 0]
       (let [api-data (extract-json-body (get-postings url limit offset))]
+        (Thread/sleep 5000) ;; avoid rate limiting
         (cond
           (= run virtual-limit) collection
           (empty? (:postings api-data)) collection


### PR DESCRIPTION
closes #4 by adding `sleep` to avoid hitting the ratelimit